### PR TITLE
Correct CentOS 6 osfinger map

### DIFF
--- a/apache/osfingermap.yaml
+++ b/apache/osfingermap.yaml
@@ -6,7 +6,7 @@ Red Hat Enterprise Linux Server-6:
   version: '2.2'
 Red Hat Enterprise Linux Server-7:
   version: '2.4'
-CentOS Linux-6:
+CentOS-6:
   version: '2.2'
 CentOS Linux-7:
   version: '2.4'


### PR DESCRIPTION
**Summary of Changes**
 * CentOS 6 reports as CentOS-6 rather than CentOS Linux-6 from osfinger grain. Formula for apache.config applies Apache 2.4 style when it should use Apache 2.2 syntax

**Testing**
 - Tested in Vagrant
 - Tested on CentOS 6 
